### PR TITLE
Lazy DbContext

### DIFF
--- a/src/Endpoint/Configuration/DbContextManagerBehavior.cs
+++ b/src/Endpoint/Configuration/DbContextManagerBehavior.cs
@@ -4,24 +4,38 @@ using System.Threading.Tasks;
 using NServiceBus;
 using NServiceBus.Pipeline;
 
-public class DbContextManagerBehavior<TDbContext> : Behavior<IInvokeHandlerContext> where TDbContext : DbContext
+public class DbContextManagerBehavior<T> : Behavior<IInvokeHandlerContext> where T : DbContext
 {
     public override async Task Invoke(IInvokeHandlerContext context, Func<Task> next)
     {
-        var session = context.SynchronizedStorageSession;
-        var sqlPersistenceSession = session.SqlPersistenceSession();
-        var dbContext = (TDbContext)Activator.CreateInstance(typeof(TDbContext), sqlPersistenceSession.Connection);
-
-        using (dbContext)
+        var lazyContext = new Lazy<T>(() =>
         {
+            var session = context.SynchronizedStorageSession;
+            var sqlPersistenceSession = session.SqlPersistenceSession();
+            var dbContext = (T)Activator.CreateInstance(typeof(T), sqlPersistenceSession.Connection);
             dbContext.Database.UseTransaction(sqlPersistenceSession.Transaction);
-            context.Extensions.Set(dbContext);
+            return dbContext;
+        });
 
+        context.Extensions.Set(lazyContext);
+
+        try
+        {
             await next()
                 .ConfigureAwait(false);
 
-            await dbContext.SaveChangesAsync()
-                .ConfigureAwait(false);
+            if (lazyContext.IsValueCreated)
+            {
+                await lazyContext.Value.SaveChangesAsync()
+                    .ConfigureAwait(false);
+            }
+        }
+        finally
+        {
+            if (lazyContext.IsValueCreated)
+            {
+                lazyContext.Value.Dispose();
+            }
         }
     }
 }

--- a/src/Endpoint/OrderStorage/DbContextWrapper.cs
+++ b/src/Endpoint/OrderStorage/DbContextWrapper.cs
@@ -9,9 +9,9 @@ class DbContextWrapper<T> : IDbContextWrapper<T> where T : DbContext
 {
     public T Get(IMessageHandlerContext context)
     {
-        if (context.Extensions.TryGet(out T dataContext))
+        if (context.Extensions.TryGet(out Lazy<T> dataContext))
         {
-            return dataContext;
+            return dataContext.Value;
         }
         throw new Exception($"No DbContext set for '{typeof(T)}.");
     }


### PR DESCRIPTION
DbContext is now lazy, which means it is only created if actually used in a handler.